### PR TITLE
Update bro-pkg.meta

### DIFF
--- a/bro-pkg.meta
+++ b/bro-pkg.meta
@@ -1,2 +1,4 @@
 [package]
-version = 0.0.1
+description = Raise notices on outgoing files over X bytes in size.
+  Also raise notices for multiple large outgoing Tx's in Y time frame.
+tags = notices, uploads, conns


### PR DESCRIPTION
In the near future, bro-pkg will expect to find all package metadata in bro-pkg.meta instead of having tags/description fields maintained separately in package source's bro-pkg.index.

The version field can be removed.  Instead, use git tags for versioning (optional).  More info on versioning here:

http://bro-package-manager.readthedocs.io/en/latest/package.html#package-versioning